### PR TITLE
Feat/tls localhost - main-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,9 +1391,9 @@ dependencies = [
  "futures-util",
  "http 0.2.11",
  "hyper 0.14.28",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2100,6 +2100,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "rfc7239",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2110,6 +2111,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
@@ -2398,7 +2400,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.10",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -2408,7 +2410,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -2560,8 +2562,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2586,12 +2602,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3336,7 +3369,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ poem-openapi = { version = "4.0.0", features = [
     "chrono",
     "uuid",
 ] }
-poem = { version = "2.0.0", features = ["cookie", "static-files"] }
+poem = { version = "2.0.0", features = ["cookie", "static-files", "rustls"] }
 
 
 [dev-dependencies]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -33,4 +33,7 @@ lazy_static! {
     pub static ref JWT_REFRESH_TOKEN_SECRET: String = var("JWT_REFRESH_TOKEN_SECRET").unwrap_or("secret".into());
     //
     pub static ref STATIC_PAGE_ENABLED: bool = var("STATIC_PAGE_ENABLED").unwrap_or("false".into()).to_lowercase() == "true";
+
+    pub static ref CERT_PEM_PATH: String = var("CERT_PEM_PATH").unwrap_or("none".into());
+    pub static ref KEY_PEM_PATH: String = var("KEY_PEM_PATH").unwrap_or("none".into());
 }

--- a/src/core/prelude.rs
+++ b/src/core/prelude.rs
@@ -21,7 +21,7 @@ impl Core {
             }
             Err(e) => {
                 println!("Error checking for default admin user: {}", e);
-                return Err(Box::new(e));
+                //podría agregarse una lógica adicional?
             }
             _ => {}
         }


### PR DESCRIPTION
### Issue Resolved: Inability to Set Plexo Session Token

**Problem**: The `plexo-session-token` couldn't be set due to issues with cookie attributes, particularly `SameSite` and `Secure`.

**Resolution**: This pull request addresses the issue by utilizing a TLS certificate in the server creation process. Below are the steps to implement this solution:

1. Install `mkcert` if you haven't already

2. Generate a local certificate authority (CA):

   ```bash
   mkcert -install
   ```

3. Create TLS certificates for your server:

   ```bash
   mkcert localhost 0.0.0.0
   ```
4. Add those files created(certificate.pem and key.pem) to your `.env` file:

   ```env
   CERT_PEM_PATH="/path/to/file"
   KEY_PEM_PATH="/path/to/file"
   ```