### PR TITLE
feat: refactor resources mutation methods to register changes

### DIFF
--- a/src/api/graphql/operations/changes.rs
+++ b/src/api/graphql/operations/changes.rs
@@ -51,42 +51,11 @@ impl ChangesGraphQLMutation {
         let mut input = input;
         input.owner_id = member_id;
 
-        let saved_input = input.clone();
-
-        let change = core.engine.create_change(input).await?;
-        let saved_change = change.clone();
-
-        let input = saved_input.clone();
-
-        task::spawn(async move {
-            create_change(
-                &core,
-                member_id,
-                change.id,
-                ChangeOperation::Insert,
-                ChangeResourceType::Changes,
-                serde_json::to_string(&json!({
-                    "input": input,
-                    "result": change,
-                }))
-                .unwrap(),
-            )
+        core.engine
+            .create_change(input)
             .await
-            .unwrap();
-        });
-
-        Ok(saved_change.into())
-
-        // let (core, member_id) = extract_context(ctx)?;
-
-        // let mut input = input;
-        // input.owner_id = member_id;
-
-        // core.engine
-        //     .create_change(input)
-        //     .await
-        //     .map_err(|err| async_graphql::Error::new(err.to_string()))
-        //     .map(|change| change.into())
+            .map_err(|err| async_graphql::Error::new(err.to_string()))
+            .map(|change| change.into())
     }
 
     async fn update_change(&self, ctx: &Context<'_>, id: Uuid, input: UpdateChangeInput) -> Result<Change> {

--- a/src/api/graphql/operations/labels.rs
+++ b/src/api/graphql/operations/labels.rs
@@ -1,10 +1,15 @@
-use crate::api::graphql::{commons::extract_context, resources::labels::Label};
+use crate::api::graphql::{
+    commons::{create_change, extract_context},
+    resources::labels::Label,
+};
 use async_graphql::{Context, Object, Result, Subscription};
 
 use plexo_sdk::resources::{
-    changes::change::{ChangeResourceType, ListenEvent},
+    changes::change::{ChangeOperation, ChangeResourceType, ListenEvent},
     labels::operations::{CreateLabelInput, GetLabelsInput, LabelCrudOperations, UpdateLabelInput},
 };
+use serde_json::json;
+use tokio::task;
 use tokio_stream::{Stream, StreamExt};
 use uuid::Uuid;
 
@@ -41,23 +46,66 @@ pub struct LabelsGraphQLMutation;
 impl LabelsGraphQLMutation {
     // TODO: It's possible that this method may not work correctly, as the owner_id is being ignored by async_graphql
     async fn create_label(&self, ctx: &Context<'_>, input: CreateLabelInput) -> Result<Label> {
-        let (core, _member_id) = extract_context(ctx)?;
+        let (core, member_id) = extract_context(ctx)?;
 
-        core.engine
-            .create_label(input)
+        let mut input = input;
+        input.owner_id = member_id;
+
+        let saved_input = input.clone();
+
+        let label = core.engine.create_label(input).await?;
+        let saved_label = label.clone();
+
+        let input = saved_input.clone();
+
+        task::spawn(async move {
+            create_change(
+                &core,
+                member_id,
+                label.id,
+                ChangeOperation::Insert,
+                ChangeResourceType::Labels,
+                serde_json::to_string(&json!({
+                    "input": input,
+                    "result": label,
+                }))
+                .unwrap(),
+            )
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))
-            .map(|label| label.into())
+            .unwrap();
+        });
+
+        Ok(saved_label.into())
     }
 
     async fn update_label(&self, ctx: &Context<'_>, id: Uuid, input: UpdateLabelInput) -> Result<Label> {
-        let (core, _member_id) = extract_context(ctx)?;
+        let (core, member_id) = extract_context(ctx)?;
 
-        core.engine
-            .update_label(id, input)
+        let saved_input = input.clone();
+
+        let label = core.engine.update_label(id, input).await?;
+
+        let label = label.clone();
+        let saved_label = label.clone();
+
+        tokio::spawn(async move {
+            create_change(
+                &core,
+                member_id,
+                label.id,
+                ChangeOperation::Update,
+                ChangeResourceType::Labels,
+                serde_json::to_string(&json!({
+                    "input": saved_input,
+                    "result": label,
+                }))
+                .unwrap(),
+            )
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))
-            .map(|label| label.into())
+            .unwrap();
+        });
+
+        Ok(saved_label.into())
     }
 
     async fn delete_label(&self, ctx: &Context<'_>, id: Uuid) -> Result<Label> {

--- a/src/api/graphql/operations/projects.rs
+++ b/src/api/graphql/operations/projects.rs
@@ -1,10 +1,16 @@
-use crate::api::graphql::{commons::extract_context, resources::projects::Project};
+use crate::api::graphql::{
+    commons::{create_change, extract_context},
+    resources::projects::Project,
+};
 use async_graphql::{Context, Object, Result, Subscription};
 
 use plexo_sdk::resources::{
-    changes::change::{ChangeResourceType, ListenEvent},
+    changes::change::{ChangeOperation, ChangeResourceType, ListenEvent},
     projects::operations::{CreateProjectInput, GetProjectsInput, ProjectCrudOperations, UpdateProjectInput},
 };
+
+use serde_json::json;
+use tokio::task;
 use tokio_stream::{Stream, StreamExt};
 use uuid::Uuid;
 
@@ -46,21 +52,72 @@ impl ProjectsGraphQLMutation {
         let mut input = input;
         input.owner_id = member_id;
 
-        core.engine
-            .create_project(input)
+        let saved_input = input.clone();
+
+        let project = core.engine.create_project(input).await?;
+        let saved_project = project.clone();
+
+        let input = saved_input.clone();
+
+        task::spawn(async move {
+            create_change(
+                &core,
+                member_id,
+                project.id,
+                ChangeOperation::Insert,
+                ChangeResourceType::Projects,
+                serde_json::to_string(&json!({
+                    "input": input,
+                    "result": project,
+                }))
+                .unwrap(),
+            )
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))
-            .map(|project| project.into())
+            .unwrap();
+        });
+
+        Ok(saved_project.into())
+
+        // let (core, member_id) = extract_context(ctx)?;
+
+        // let mut input = input;
+        // input.owner_id = member_id;
+
+        // core.engine
+        //     .create_project(input)
+        //     .await
+        //     .map_err(|err| async_graphql::Error::new(err.to_string()))
+        //     .map(|project| project.into())
     }
 
     async fn update_project(&self, ctx: &Context<'_>, id: Uuid, input: UpdateProjectInput) -> Result<Project> {
-        let (core, _member_id) = extract_context(ctx)?;
+        let (core, member_id) = extract_context(ctx)?;
 
-        core.engine
-            .update_project(id, input)
+        let saved_input = input.clone();
+
+        let project = core.engine.update_project(id, input).await?;
+
+        let project = project.clone();
+        let saved_project = project.clone();
+
+        tokio::spawn(async move {
+            create_change(
+                &core,
+                member_id,
+                project.id,
+                ChangeOperation::Update,
+                ChangeResourceType::Projects,
+                serde_json::to_string(&json!({
+                    "input": saved_input,
+                    "result": project,
+                }))
+                .unwrap(),
+            )
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))
-            .map(|project| project.into())
+            .unwrap();
+        });
+
+        Ok(saved_project.into())
     }
 
     async fn delete_project(&self, ctx: &Context<'_>, id: Uuid) -> Result<Project> {

--- a/src/api/graphql/operations/teams.rs
+++ b/src/api/graphql/operations/teams.rs
@@ -1,11 +1,16 @@
-use crate::api::graphql::{commons::extract_context, resources::teams::Team};
+use crate::api::graphql::{
+    commons::{create_change, extract_context},
+    resources::teams::Team,
+};
 use async_graphql::{Context, Object, Result, Subscription};
 
 use plexo_sdk::resources::{
-    changes::change::{ChangeResourceType, ListenEvent},
+    changes::change::{ChangeOperation, ChangeResourceType, ListenEvent},
     teams::operations::{CreateTeamInput, GetTeamsInput, TeamCrudOperations, UpdateTeamInput},
 };
 
+use serde_json::json;
+use tokio::task;
 use tokio_stream::{Stream, StreamExt};
 use uuid::Uuid;
 
@@ -47,21 +52,78 @@ impl TeamsGraphQLMutation {
         let mut input = input;
         input.owner_id = member_id;
 
-        core.engine
-            .create_team(input)
+        let saved_input = input.clone();
+
+        let team = core.engine.create_team(input).await?;
+        let saved_team = team.clone();
+
+        let input = saved_input.clone();
+
+        task::spawn(async move {
+            create_change(
+                &core,
+                member_id,
+                team.id,
+                ChangeOperation::Insert,
+                ChangeResourceType::Teams,
+                serde_json::to_string(&json!({
+                    "input": input,
+                    "result": team,
+                }))
+                .unwrap(),
+            )
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))
-            .map(|team| team.into())
+            .unwrap();
+        });
+
+        Ok(saved_team.into())
+
+        // let (core, member_id) = extract_context(ctx)?;
+
+        // let mut input = input;
+        // input.owner_id = member_id;
+
+        // core.engine
+        //     .create_team(input)
+        //     .await
+        //     .map_err(|err| async_graphql::Error::new(err.to_string()))
+        //     .map(|team| team.into())
     }
 
     async fn update_team(&self, ctx: &Context<'_>, id: Uuid, input: UpdateTeamInput) -> Result<Team> {
-        let (core, _member_id) = extract_context(ctx)?;
+        let (core, member_id) = extract_context(ctx)?;
 
-        core.engine
-            .update_team(id, input)
+        let saved_input = input.clone();
+
+        let team = core.engine.update_team(id, input).await?;
+
+        let team = team.clone();
+        let saved_team = team.clone();
+
+        tokio::spawn(async move {
+            create_change(
+                &core,
+                member_id,
+                team.id,
+                ChangeOperation::Update,
+                ChangeResourceType::Teams,
+                serde_json::to_string(&json!({
+                    "input": saved_input,
+                    "result": team,
+                }))
+                .unwrap(),
+            )
             .await
-            .map_err(|err| async_graphql::Error::new(err.to_string()))
-            .map(|team| team.into())
+            .unwrap();
+        });
+
+        Ok(saved_team.into())
+
+        // core.engine
+        //     .update_team(id, input)
+        //     .await
+        //     .map_err(|err| async_graphql::Error::new(err.to_string()))
+        //     .map(|team| team.into())
     }
 
     async fn delete_team(&self, ctx: &Context<'_>, id: Uuid) -> Result<Team> {


### PR DESCRIPTION
`members` resource wasn't refactored because I need to use a setter defined by `plexo-sdk`. In the same way, some structs (e.g. plexo_sdk::resources::projects::operations::UpdateProjectInput, plexo_sdk::resources::teams::team::Team) expect Clone & Serialized implemented traits